### PR TITLE
Sponsors page

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ export const SIDEBAR = {
 		{ text: '', header: true },
 		{ text: 'Home', link: '' },
 		{ text: 'Code of Conduct', link: 'https://github.com/email-markup-consortium/email-markup-consortium/blob/main/code-of-conduct.md' },
+		{ text: 'Sponsors', link: 'en/sponsors' },
 
 		{ text: 'Pages', header: true },
 		{ text: 'Mission', link: 'en/docs/mission' },

--- a/src/pages/en/sponsors.md
+++ b/src/pages/en/sponsors.md
@@ -1,0 +1,34 @@
+---
+title: EMC Sponsorship
+description:
+layout: "@layouts/MainLayout"
+---
+
+## Become an EMC sponsor
+
+The Email Markup Consortium is an independently run community project. To keep the project sustainable and to keep ourselves independent, we rely on donations and sponsorship to keep running.
+
+## Why Sponsor us?
+
+Sponsoring the EMC not only gives you great exposure to all our members and follows but also helps drive the email industry forward with a goal of making things better for email senders, email clients, recipients and anyone else involved.
+
+## What you get
+
+- Prominent logo placement on the front page of EmailMarkup.org
+- Prominent logo placement in sidebar of all pages in the [docs section of the site](https://emailmarkup.org/en/docs/)
+- Prominent logo placement in our email newsletter
+- Any documentation, tools or services created in collaboration between your brand and the ENC will also be fully credited.
+
+## How to sponsor us
+
+We have a few options for sponsorship
+
+- Contribute financially [via our Open Collective page](https://opencollective.com/email-markup-consortium/contribute/sponsor-42999/checkout), where you will be able to see how your money is spent.
+- You can commit a set amount of hours to work on projects within the Email Markup Consortium.
+- Provide needed resources used in the running of the Email Markup Consortium
+
+## How we plan to spend the money
+
+All expenses will be listed on our [Open Collective expenses page](https://opencollective.com/email-markup-consortium/expenses). These expenses will include tools, software and services used by the EMC to maintain our website and marketing presence, create and run reports, build tools and services to be used by the community.
+
+If you’d like to know more about how the money will be held and processed you can find out more on the websites of our money management platform [OpenCollective.com](https://opencollective.com/) and our fiscal host [osCollective.org](https://www.oscollective.org/).


### PR DESCRIPTION
This PR just adds the main content of the Sponsors page. 

I think we'll handle the logos in a separate PR. I'd like the logos on the home page and this page to be managed from a single Astro component. Plus the logos we have currently are white (clash with the background colour of this page). 

---

Should this be `/en/sponsors` (noun, plural) or `/en/sponsor` (verb)?