### PR TITLE
Add reports/accessibility section

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,6 +40,9 @@ export const SIDEBAR = {
 		{ text: 'Pages', header: true },
 		{ text: 'Mission', link: 'en/docs/mission' },
 		{ text: 'Glossary', link: 'en/docs/glossary' },
-		{ text: 'Compliant Standards', link: 'en/docs/compliant-standards' }
+		{ text: 'Compliant Standards', link: 'en/docs/compliant-standards' },
+
+		{ text: 'Reports', header: true },
+		{ text: 'Accessibility', link: 'en/reports/accessibility' },
 	],
 };

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -64,11 +64,11 @@ After some additional manual testing on these campaigns, the Email On Acid email
 
 Found in 86.1% of emails tested.
 
-#### Why it’s needed:
+##### Why it’s needed:
 
 This defines the language for the email, it can help with translation tools but the main reason it’s needed is for tools like screen readers. If a screen reader is set to the wrong language it can change the pronunciation of words which in turn could make it completely unusable.
 
-#### How to fix this:
+##### How to fix this:
 
 This can be fixed by adding a `<div>` as the first child of the `<body>` element with a `lang=""` attribute set on it with the appropriate language. We need this set inside the `<body>` and on the `<html>` tag as some email clients will strip parts of the code before displaying it.
 
@@ -101,7 +101,7 @@ This defines the language for the email, it can help with translation tools but 
 
 ##### How to fix this:
 
-This can be fixed by adding a `lang=""` attribute to the `<html>` tag. This is in addition to the [Content inside the body should be wrapped in a `lang` attribute](https://docs.google.com/document/d/16M3gFklJt_z_GbeCMWXxMevJRrF9WsrjMCnAY39HK9I/edit#heading=h.7a1a3e736rfw) issue mentioned above.
+This can be fixed by adding a `lang=""` attribute to the `<html>` tag. This is in addition to the [Content inside the body should be wrapped in a `lang` attribute](#1-serious-content-inside-the-body-should-be-wrapped-in-a-lang-attribute) issue mentioned above.
 
 When setting a `lang=""` attribute it’s always good to set a `dir=""` attribute too, to define the direction of the language.
 Learn more about `lang` attributes.

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -1,6 +1,209 @@
 ---
 title: Accessibility Report July 2022
 publishDate: 28 July 2022
-description: 
-layout: '@layouts/MainLayout'
+description: Email Markup Consortium Accessibility Report - July 2022
+layout: "@layouts/MainLayout"
 ---
+
+This is our first accessibility report. We intend to publish one on a regular basis to report on the state of accessibility in the email industry. We hope this will help to encourage people to fix accessibility issues so we will see a trend in improvement over time. As you’ll see from the results we have a long way to go.
+
+## The data
+
+The data was sourced by the Email Markup Consortium [Data Collection project](https://dev.to/emailmarkup/collecting-data-1gdb) between 16th May 2022 and 22 July 2022. We collected 35,604 emails from multiple industries in multiple languages. We have attempted to diversify our data set as much as possible. Around 50% of the emails we analyzed were written in languages other than English.
+
+If you would like to add to and help expand our dataset or find out more about it, you can [read more about our data collection project](https://dev.to/emailmarkup/collecting-data-1gdb).
+
+## Testing methodology
+
+The testing is performed via [Parcel](https://parcel.io/) accessibility checker. This is a tool built specifically for email accessibility tests. Learn more about the tests and what they cover by reading the [Parcel accessibility-checker documentation](https://parcel.io/docs/dev-tools/accessibility-checker).
+
+We’d like to give huge thanks to the team at [Parcel.io](https://parcel.io/) for all the help with collecting the data and running the tests. The accessibility checker is available on the free plan at Parcel, so if you want to test your emails on the same criteria that we use you can do so very easily, and add it into your regular email production workflow.
+
+## Results
+
+### Issues severity
+
+Accessibility issues are categorized into 4 categories depending on how serious they are. These are defined by Deque Axe as:
+
+- **Mild** - Considered to be a nuisance or an annoyance bug. Prioritize fixing if the fix only takes a few minutes and the developer is working on the same screen/feature at the same time, otherwise the issue should not be prioritized. Will still get in the way of compliance if not fixed. Should be very infrequent.
+- **Moderate** - Results in some barriers for people with disabilities, but will not prevent them from accessing fundamental features or content. Prioritize fixing in this release, if there are no higher-priority issues. Will get in the way of compliance if not fixed. Should be fairly common.
+- **Serious** - Results in serious barriers for people with disabilities, and will partially prevent them from accessing fundamental features or content. People relying on assistive technologies will experience significant frustration as a result. Issues falling under this category are major problems, and remediation should be a priority. Should be very common.
+- **Critical** - Results in blocked content for people with disabilities, and will definitely prevent them from accessing fundamental features or content. This type of issue puts your organization at risk. Prioritize fixing as soon as possible, within the week if possible. Remediation should be a top priority. Should be infrequent.
+
+In our test we looked to find the highest category of issue recorded in each email:
+
+| Issue severity | Percentage of emails |
+| -------------- | -------------------- |
+| Critical       | 49.53%               |
+| Serious        | 50.39%               |
+| Moderate       | 0.04%                |
+| Mild           | 0%                   |
+| No issues      | 0.03%                |
+
+From this we can see that 99.9% of emails tested contain accessibility issues categorized as “Serious” or “Critical”. These are the highest categories and fixing any of these issues should be considered high priority. We knew things were bad but this is much worse than we were expecting.
+
+Out of all the emails tested there were only 11 that passed without issue, and those were from just 3 senders.
+
+So congratulations to
+
+- [Email On Acid](https://www.emailonacid.com/) (1 email)
+- [Blocks Edit](https://blocksedit.com/) (2 emails)
+- [Basta!](https://basta.media/) (8 emails)
+
+All three of these brands are setting a great example of what can be done.
+
+After some additional manual testing on these campaigns, the Email On Acid email came out on top. So if you’re looking for an example of what to aim for, you can [view the most accessible email from our test](https://marketing.emailonacid.com/ebook-the-omnichannel-heros-journey-2).
+
+### Top 10 most common accessibility issues in email
+
+#### (1) Serious: Content inside the body should be wrapped in a `lang` attribute
+
+Found in 86.1% of emails tested.
+
+#### Why it’s needed:
+
+This defines the language for the email, it can help with translation tools but the main reason it’s needed is for tools like screen readers. If a screen reader is set to the wrong language it can change the pronunciation of words which in turn could make it completely unusable.
+
+#### How to fix this:
+
+This can be fixed by adding a `<div>` as the first child of the `<body>` element with a `lang=""` attribute set on it with the appropriate language. We need this set inside the `<body>` and on the `<html>` tag as some email clients will strip parts of the code before displaying it.
+
+When setting a `lang=""` attribute it’s always good to set a `dir=""` attribute too, to define the direction of the language.
+Learn more about `lang` attributes
+
+---
+
+#### (2) Moderate: Page should contain a level-one heading
+
+Found in 85.7% of emails tested.
+
+##### Why it’s needed:
+
+According to the [2021 WebAIM screen reader user survey](https://webaim.org/projects/screenreadersurvey9/#finding) 67.7% use headings as their primary way of finding information. Having an `<h1>` in the email means they can quickly and easily find the email in the page and the information inside it.
+
+##### How to fix this:
+
+Add an `<h1>` tag around the main heading of the email. You should only use one `<h1>` after that you can use `<h2>` headings as sub headings under that main heading, and `<h3>` as a sub heading of the `<h2>` all the way down to `<h6>`.
+
+---
+
+#### (3) Serious: `<html>` element must have a `lang` attribute
+
+Found in 78.8% of emails tested.
+
+##### Why it’s needed:
+
+This defines the language for the email, it can help with translation tools but the main reason it’s needed is for tools like screen readers. If a screen reader is set to the wrong language it can change the pronunciation of words which in turn could make it completely unusable.
+
+##### How to fix this:
+
+This can be fixed by adding a `lang=""` attribute to the `<html>` tag. This is in addition to the [Content inside the body should be wrapped in a `lang` attribute](https://docs.google.com/document/d/16M3gFklJt_z_GbeCMWXxMevJRrF9WsrjMCnAY39HK9I/edit#heading=h.7a1a3e736rfw) issue mentioned above.
+
+When setting a `lang=""` attribute it’s always good to set a `dir=""` attribute too, to define the direction of the language.
+Learn more about `lang` attributes.
+
+---
+
+#### (4) Serious: Tables used for formatting should have the `role` attribute set to `presentation` or `none`
+
+Found in 78.4% of emails tested.
+
+##### Why it’s needed:
+
+`<table>` elements are designed to be used for tabular data, not for laying out content. When a screen reader encounters a table it will read it as tabular data, looking at the context of the cell within the rows and columns of the table.
+
+##### How to fix this:
+
+If you are using table elements for layout, then add `role="presentation"` or `role="none"` to each layout table used. However if you are displaying a table of data then you should not use this, but be sure to markup the headings correctly.
+
+---
+
+#### (5) Serious: Links must have discernible text
+
+Found in 61.6% of emails tested.
+
+##### Why it’s needed:
+
+Link text tells the user where the link will direct them, without any text they won’t know what the link is for. This is particularly bad for screen reader users.
+
+##### How to fix this:
+
+Add some text inside the `<a>` tag. This issue often comes up when an image has a link around it but no alt text, in that case adding an `alt=""` attribute with appropriate text will fix the issue.
+
+---
+
+#### (6) Serious: Documents must have `<title>` element to aid in navigation
+
+Found in 45% of emails tested.
+
+##### Why it’s needed:
+
+The title will show if the email is viewed as a webpage, this shows in the browser tab helping users find it amongst other tabs. A screen reader will also announce the title when the user navigates to that tab.
+
+##### How to fix this:
+
+Add a `<title>` element with some appropriate text inside the `<head>`.
+
+---
+
+#### (7) Critical: Images must have alternate text
+
+Found in 44.5% of emails tested.
+
+##### Why it’s needed:
+
+Alt text is used to describe an image to someone using a screen reader. Images are often added to email to help convey a message to the user, so we need that message to pass across to all users.
+
+##### How to fix this:
+
+Add an `alt=""` attribute to the`<img>` element with appropriate text. If the image is purely there for decoration and not adding to the message or meaning of the content, then you should still include an `alt=""` attribute, but you can leave it blank.
+
+---
+
+#### (8) Moderate: Link text should be descriptive.
+
+Found in 15.8% of emails tested.
+
+##### Why it’s needed:
+
+Link text tells the user where the link will take them so a good description makes them more informed. Also screen readers have a feature that shows a list of all the links in a page, this only displays the link text and none of the text around it which might be used to add context.
+
+##### How to fix this:
+
+Avoid generic text like “click here” or “find out more”. Use text that identifies the purpose of the link without needing additional context. [Learn more about link text](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)
+
+---
+
+#### (9) Critical: Zooming and scaling should not be disabled
+
+Found in 9.3% of emails tested.
+
+##### Why it’s needed:
+
+Even when you’re using good sized text and clear layout there are still many cases where people will need to zoom in to see things more clearly.
+
+##### How to fix this:
+
+If you are using a `<meta name="viewport">` make sure the `user-scalable` value is set to `1` or `yes` and the `maximum-scale` is set to at least `5`.
+
+You can also just remove these setting as the default values are `user-scalable=yes, maximum-scale=10`
+
+---
+
+#### (10) Moderate: Email should have exactly one h1 tag (but has more than one).
+
+Found in 9.1% of emails tested.
+
+##### Why it’s needed:
+
+We’ve already mentioned why an `<h1>` is needed. But adding more than one can be very confusing for users and they get lost trying to navigate the email.
+
+##### How to fix this:
+
+Decide on which is the main heading, usually this is the first one, leave that as `<h1>` and move all the others down to `<h2>` or lower.
+
+## Conclusions
+
+From looking at these results, it’s clear we still have a very long way to go. There are a large number of issues, however these are repeated a lot so there is not that much to fix. If everyone were to fix just the top 5 issues listed here that would turn these results around. And most of these fixes only require very small changes.
+
+These results are based on the analysis of 35,604 emails collected over the last 2 months. In terms of the email industry as a whole this is a very small number, however the results do match a [previous test done by the Parcel team](https://twitter.com/theavigoldman/status/1518742382975541248).

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -7,6 +7,10 @@ layout: "@layouts/MainLayout"
 
 This is our first accessibility report. We intend to publish one on a regular basis to report on the state of accessibility in the email industry. We hope this will help to encourage people to fix accessibility issues so we will see a trend in improvement over time. As you’ll see from the results we have a long way to go.
 
+> **Result**
+>
+> 99.9% out of 35,604 HTML emails tested contain accessibility issues categorized as “Serious” or “Critical”.
+
 ## The data
 
 The data was sourced by the Email Markup Consortium [Data Collection project](https://dev.to/emailmarkup/collecting-data-1gdb) between 16th May 2022 and 22 July 2022. We collected 35,604 emails from multiple industries in multiple languages. We have attempted to diversify our data set as much as possible. Around 50% of the emails we analyzed were written in languages other than English.

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -1,0 +1,6 @@
+---
+title: Accessibility Report July 2022
+publishDate: 28 July 2022
+description: 
+layout: '@layouts/MainLayout'
+---

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -21,7 +21,7 @@ If you would like to add to and help expand our dataset or find out more about i
 
 The testing is performed via [Parcel](https://parcel.io/) accessibility checker. This is a tool built specifically for email accessibility tests. Learn more about the tests and what they cover by reading the [Parcel accessibility-checker documentation](https://parcel.io/docs/dev-tools/accessibility-checker).
 
-We’d like to give huge thanks to the team at [Parcel.io](https://parcel.io/) for all the help with collecting the data and running the tests. The accessibility checker is available on the free plan at Parcel, so if you want to test your emails on the same criteria that we use you can do so very easily, and add it into your regular email production workflow.
+We’d like to give huge thanks to the team at [Parcel.io](https://parcel.io/) for all the help with collecting the data and running the tests. The accessibility checker is available on the free Community plan at Parcel, so if you want to test your emails on the same criteria that we use you can do so very easily, and add it into your regular email production workflow.
 
 ## Results
 

--- a/src/pages/en/reports/accessibility/index.md
+++ b/src/pages/en/reports/accessibility/index.md
@@ -16,6 +16,15 @@ Reports published here relies on data sourced by the the Email Markup Consortium
 
 The testing is performed via [Parcel](https://parcel.io/) accessibility checker unless stated otherwise. This is a tool built specifically for email accessibility tests. Learn more about the tests and what they cover by reading the [Parcel accessibility-checker documentation](https://parcel.io/docs/dev-tools/accessibility-checker).
 
+## Issues severity categories
+
+Accessibility issues are categorized into 4 categories depending on how serious they are. These are defined by Deque Axe as:
+
+- **Mild** - Considered to be a nuisance or an annoyance bug. Prioritize fixing if the fix only takes a few minutes and the developer is working on the same screen/feature at the same time, otherwise the issue should not be prioritized. Will still get in the way of compliance if not fixed. Should be very infrequent.
+- **Moderate** - Results in some barriers for people with disabilities, but will not prevent them from accessing fundamental features or content. Prioritize fixing in this release, if there are no higher-priority issues. Will get in the way of compliance if not fixed. Should be fairly common.
+- **Serious** - Results in serious barriers for people with disabilities, and will partially prevent them from accessing fundamental features or content. People relying on assistive technologies will experience significant frustration as a result. Issues falling under this category are major problems, and remediation should be a priority. Should be very common.
+- **Critical** - Results in blocked content for people with disabilities, and will definitely prevent them from accessing fundamental features or content. This type of issue puts your organization at risk. Prioritize fixing as soon as possible, within the week if possible. Remediation should be a top priority. Should be infrequent.
+
 ## Reports
 
 <ul>

--- a/src/pages/en/reports/accessibility/index.md
+++ b/src/pages/en/reports/accessibility/index.md
@@ -1,0 +1,29 @@
+---
+title: Accessibility Reports
+description:
+layout: "@layouts/MainLayout"
+
+setup: |
+  let posts = await Astro.glob('./*.md');
+  posts = posts.sort((a, b) => new Date(b.frontmatter.publishDate).valueOf() - new Date(a.frontmatter.publishDate).valueOf());
+---
+
+## Data
+
+Reports published here relies on data sourced by the the Email Markup Consortium [Data Collection project](https://dev.to/emailmarkup/collecting-data-1gdb) unless otherwise stated.
+
+## Testing methodology
+
+The testing is performed via [Parcel](https://parcel.io/) accessibility checker unless stated otherwise. This is a tool built specifically for email accessibility tests. Learn more about the tests and what they cover by reading the [Parcel accessibility-checker documentation](https://parcel.io/docs/dev-tools/accessibility-checker).
+
+## Reports
+
+<ul>
+{posts.map(post => (
+  <li>
+    <a href={post.url}>
+      {post.frontmatter.title}
+    </a>
+  </li>
+))}
+</ul>

--- a/src/pages/en/reports/accessibility/index.md
+++ b/src/pages/en/reports/accessibility/index.md
@@ -25,6 +25,14 @@ Accessibility issues are categorized into 4 categories depending on how serious 
 - **Serious** - Results in serious barriers for people with disabilities, and will partially prevent them from accessing fundamental features or content. People relying on assistive technologies will experience significant frustration as a result. Issues falling under this category are major problems, and remediation should be a priority. Should be very common.
 - **Critical** - Results in blocked content for people with disabilities, and will definitely prevent them from accessing fundamental features or content. This type of issue puts your organization at risk. Prioritize fixing as soon as possible, within the week if possible. Remediation should be a top priority. Should be infrequent.
 
+## Results interpretation
+
+We analyze the HTML email code that is sent to the user as is.
+
+The HTML that gets sent does not always reflect the efforts made by the HTML email developer to build accessible emails. This is because sender tools may modify the HTML before it is sent. Similarly, this does not mean accessibility issues are always the sender tool's fault.
+
+Email clients may also modify the HTML code that is eventually rendered on the page. This could introduce accessibility issues that the unmodified HTML email addresses. Issues introduced by email clients in the browser may not be covered in these reports.
+
 ## Reports
 
 <ul>


### PR DESCRIPTION
Adding a new section for Reports. Currently it will only contain accessibility reports.

The main page is meant to explain what these reports are, where the data is coming from and how we are analyzing the data. Under the "Reports" heading, the reports are automatically listed on build in descending order (new to old).

Still to do:

- [x] Add definitions to issue severity categories to main page
- [x] Add first report