### PR TITLE
clarification on using headings in email 

### DIFF
--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -86,7 +86,9 @@ Issue present in 85.7% of emails tested.
 
 ##### Why it’s needed:
 
-According to the [2021 WebAIM screen reader user survey](https://webaim.org/projects/screenreadersurvey9/#finding) 67.7% use headings as their primary way of finding information. Having an `<h1>` in the email means they can quickly and easily find the email in the page and the information inside it.
+According to the [2021 WebAIM screen reader user survey](https://webaim.org/projects/screenreadersurvey9/#finding) 67.7% use headings as their primary way of finding information. Having an `<h1>` in the email means they can quickly and easily find the email in the page and the information inside it. 
+
+However not all emails require headings, if it's a very simple email with no structure to the content (just a couple of paragraphs of text) then a heading may not be needed.
 
 ##### How to fix this:
 

--- a/src/pages/en/reports/accessibility/2022-07.md
+++ b/src/pages/en/reports/accessibility/2022-07.md
@@ -88,7 +88,7 @@ Issue present in 85.7% of emails tested.
 
 According to the [2021 WebAIM screen reader user survey](https://webaim.org/projects/screenreadersurvey9/#finding) 67.7% use headings as their primary way of finding information. Having an `<h1>` in the email means they can quickly and easily find the email in the page and the information inside it. 
 
-However not all emails require headings, if it's a very simple email with no structure to the content (just a couple of paragraphs of text) then a heading may not be needed.
+However not all emails require headings. For instance, a very simple email with no structure to the content (e.g. just a couple of paragraphs of text) does not require any headings.
 
 ##### How to fix this:
 


### PR DESCRIPTION
After talking with WebAim it was pointed out that not all emails require headings, so I've added some clarification around that issue.  

I think it's still important to flag it as a warning, as most of the emails we are looking at have do structured content and should include an `<h1>`.