### PR TITLE
Compliant Standards: Reference W3C TAG ethical principals

### DIFF
--- a/src/pages/en/docs/compliant-standards.md
+++ b/src/pages/en/docs/compliant-standards.md
@@ -71,7 +71,6 @@ Either use default :focus or suitable custom styling.
 
 A recipient should be able to manipulate the content to a point to make it readable. This aligns with the W3C Technical Architecture Group (TAG)'s [Ethical Web Principles](https://w3ctag.github.io/ethical-web-principles/#render):
 
-> #### People should be able to render web content as they want
 > People must be able to change web pages according to their needs. For example, people should be able to install style sheets, assistive browser extensions, and blockers of unwanted content or scripts or auto-played videos.
 
 #### Example

--- a/src/pages/en/docs/compliant-standards.md
+++ b/src/pages/en/docs/compliant-standards.md
@@ -69,7 +69,10 @@ Either use default :focus or suitable custom styling.
 
 ### 2.5 Allow for content manipulation
 
-A recipient should be able to manipulate the content to a point to make it readable.
+A recipient should be able to manipulate the content to a point to make it readable. This aligns with the W3C Technical Architecture Group (TAG)'s [Ethical Web Principles](https://w3ctag.github.io/ethical-web-principles/#render):
+
+> #### People should be able to render web content as they want
+> People must be able to change web pages according to their needs. For example, people should be able to install style sheets, assistive browser extensions, and blockers of unwanted content or scripts or auto-played videos.
 
 #### Example
 


### PR DESCRIPTION
Reference W3C TAG ethical web principals which align with the points made under "Allow for content manipulation" in the compliant standards doc.

Not sure if a direct quote is appropriate as the text could be updated. Remove the quote and keep the [link](https://w3ctag.github.io/ethical-web-principles/#render)?