### PR TITLE
Add last modified date

### DIFF
--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -6,7 +6,7 @@ const { frontmatter, headings, githubEditUrl, lastModifiedDate } = Astro.props;
 const title = frontmatter.title;
 let formattedLastModifiedDate;
 if(lastModifiedDate) {
-	formattedLastModifiedDate = `${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getDate()}, ${lastModifiedDate.getFullYear()}`;
+	formattedLastModifiedDate = `${lastModifiedDate.getDate()} ${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getFullYear()}`;
 }
 ---
 

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -16,7 +16,7 @@ if(lastModifiedDate) {
 		
 		{formattedLastModifiedDate && (
 			<p>
-				<b>Last modified:</b> <time datetime={lastModifiedDate}>{formattedLastModifiedDate}</time>
+				<b>Last modified:</b> <time datetime={lastModifiedDate.toISOString()}>{formattedLastModifiedDate}</time>
 			</p>
 		)}
 

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -2,13 +2,19 @@
 import MoreMenu from '../RightSidebar/MoreMenu.astro';
 import TableOfContents from '../RightSidebar/TableOfContents';
 
-const { frontmatter, headings, githubEditUrl } = Astro.props;
+const { frontmatter, headings, githubEditUrl, lastModifiedDate } = Astro.props;
 const title = frontmatter.title;
+const formattedLastModifiedDate = `${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getDate()}, ${lastModifiedDate.getFullYear()}`;
 ---
 
 <article id="article" class="content">
 	<section class="main-section">
 		<h1 class="content-title" id="overview">{title}</h1>
+		
+		<p>
+			<b>Last modified:</b> <time datetime={lastModifiedDate}>{formattedLastModifiedDate}</time>
+		</p>
+
 		<nav class="block sm:hidden">
 			<TableOfContents client:media="(max-width: 50em)" {headings} />
 		</nav>

--- a/src/components/PageContent/PageContent.astro
+++ b/src/components/PageContent/PageContent.astro
@@ -4,16 +4,21 @@ import TableOfContents from '../RightSidebar/TableOfContents';
 
 const { frontmatter, headings, githubEditUrl, lastModifiedDate } = Astro.props;
 const title = frontmatter.title;
-const formattedLastModifiedDate = `${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getDate()}, ${lastModifiedDate.getFullYear()}`;
+let formattedLastModifiedDate;
+if(lastModifiedDate) {
+	formattedLastModifiedDate = `${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getDate()}, ${lastModifiedDate.getFullYear()}`;
+}
 ---
 
 <article id="article" class="content">
 	<section class="main-section">
 		<h1 class="content-title" id="overview">{title}</h1>
 		
-		<p>
-			<b>Last modified:</b> <time datetime={lastModifiedDate}>{formattedLastModifiedDate}</time>
-		</p>
+		{formattedLastModifiedDate && (
+			<p>
+				<b>Last modified:</b> <time datetime={lastModifiedDate}>{formattedLastModifiedDate}</time>
+			</p>
+		)}
 
 		<nav class="block sm:hidden">
 			<TableOfContents client:media="(max-width: 50em)" {headings} />

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,8 @@ export const KNOWN_LANGUAGES = {
 };
 
 // Uncomment this to add an "Edit this page" button to every page of documentation.
-export const GITHUB_EDIT_URL = `https://github.com/email-markup-consortium/emailmarkup.org/blob/main/`;
+export const GITHUB_REPO = 'email-markup-consortium/emailmarkup.org';
+export const GITHUB_EDIT_URL = `https://github.com/${GITHUB_REPO}/blob/main/`;
 
 // Uncomment this to add an "Join our Community" button to every page of documentation.
 // export const COMMUNITY_INVITE_URL = `https://astro.build/chat`;

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -6,7 +6,6 @@ import PageContent from '@components/PageContent/PageContent';
 import LeftSidebar from '@components/LeftSidebar/LeftSidebar';
 import RightSidebar from '@components/RightSidebar/RightSidebar';
 import * as CONFIG from '../config';
-import fs from 'node:fs';
 
 import '../styles/theme.css';
 import '../styles/index.css';

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -16,9 +16,12 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
 
 const filePath = frontmatter.file;
-const { mtime: lastModifiedDate } = fs.statSync(filePath);
 const currentFile = filePath.slice(filePath.indexOf('src/pages/'));
 const githubEditUrl = CONFIG.GITHUB_EDIT_URL && CONFIG.GITHUB_EDIT_URL + currentFile;
+
+const githubResponse = await fetch(`https://api.github.com/repos/${CONFIG.GITHUB_REPO}/commits?path=${encodeURIComponent(currentFile)}&page=1&per_page=1`);
+const githubData = await githubResponse.json();
+const lastModifiedDate = new Date(githubData[0].commit.author.date);
 ---
 
 <html dir={frontmatter.dir ?? 'ltr'} lang={frontmatter.lang ?? 'en-us'} class="initial">

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -6,6 +6,7 @@ import PageContent from '@components/PageContent/PageContent';
 import LeftSidebar from '@components/LeftSidebar/LeftSidebar';
 import RightSidebar from '@components/RightSidebar/RightSidebar';
 import * as CONFIG from '../config';
+import fs from 'node:fs';
 
 import '../styles/theme.css';
 import '../styles/index.css';
@@ -15,6 +16,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const currentPage = Astro.url.pathname;
 
 const filePath = frontmatter.file;
+const { mtime: lastModifiedDate } = fs.statSync(filePath);
 const currentFile = filePath.slice(filePath.indexOf('src/pages/'));
 const githubEditUrl = CONFIG.GITHUB_EDIT_URL && CONFIG.GITHUB_EDIT_URL + currentFile;
 ---
@@ -114,7 +116,7 @@ const githubEditUrl = CONFIG.GITHUB_EDIT_URL && CONFIG.GITHUB_EDIT_URL + current
 				<LeftSidebar {currentPage} />
 			</aside>
 			<div id="grid-main">
-				<PageContent {frontmatter} {headings} {githubEditUrl}>
+				<PageContent {frontmatter} {headings} {githubEditUrl} {lastModifiedDate}>
 					<slot />
 				</PageContent>
 			</div>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -20,7 +20,7 @@ const githubEditUrl = CONFIG.GITHUB_EDIT_URL && CONFIG.GITHUB_EDIT_URL + current
 
 const githubResponse = await fetch(`https://api.github.com/repos/${CONFIG.GITHUB_REPO}/commits?path=${encodeURIComponent(currentFile)}&page=1&per_page=1`);
 const githubData = await githubResponse.json();
-const lastModifiedDate = new Date(githubData[0].commit.author.date);
+const lastModifiedDate = githubData.length ? new Date(githubData[0].commit.author.date) : null;
 ---
 
 <html dir={frontmatter.dir ?? 'ltr'} lang={frontmatter.lang ?? 'en-us'} class="initial">


### PR DESCRIPTION
This PR adds the last modified date of a document. Closes #33 

This just reads the last modified date via the file system instead of querying GitHub. Not sure if this would get us any unexpected values. Worth checking the Netlify previews.

---

Update: that did not work unfortunately (always get the day's date). Switching this to draft for now.

---

Update: Date is now fetched from GitHub's public API. Example:
https://api.github.com/repos/email-markup-consortium/emailmarkup.org/commits?path=src%2Fpages%2Fen%2Fdocs%2Findex.md&page=1&per_page=1