### PR TITLE
Add History link

### DIFF
--- a/src/components/RightSidebar/MoreMenu.astro
+++ b/src/components/RightSidebar/MoreMenu.astro
@@ -30,6 +30,30 @@ const showMoreSection = CONFIG.COMMUNITY_INVITE_URL || editHref;
 				<span>Edit this page</span>
 			</a>
 		</li>
+		<li class={`heading-link depth-2`}>
+			<a href={editHref.replace('blob/main', 'commits/main')} target="_blank">
+				<svg 
+					aria-hidden="true"
+					focusable="false"
+					data-prefix="fas"
+					data-icon="clock-rotate-left"
+					xmlns="http://www.w3.org/2000/svg"
+				 	viewBox="0 0 512 512"
+					class="svg-inline--fa fa-clock-rotate-left fa-w-16"
+					role="img"
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 512 512"
+					height="1em"
+					width="1em"
+				>
+					<path
+						fill="currentColor"
+						d="M256 0C397.4 0 512 114.6 512 256C512 397.4 397.4 512 256 512C201.7 512 151.2 495 109.7 466.1C95.2 455.1 91.64 436 101.8 421.5C111.9 407 131.8 403.5 146.3 413.6C177.4 435.3 215.2 448 256 448C362 448 448 362 448 256C448 149.1 362 64 256 64C202.1 64 155 85.46 120.2 120.2L151 151C166.1 166.1 155.4 192 134.1 192H24C10.75 192 0 181.3 0 168V57.94C0 36.56 25.85 25.85 40.97 40.97L74.98 74.98C121.3 28.69 185.3 0 255.1 0L256 0zM256 128C269.3 128 280 138.7 280 152V246.1L344.1 311C354.3 320.4 354.3 335.6 344.1 344.1C335.6 354.3 320.4 354.3 311 344.1L239 272.1C234.5 268.5 232 262.4 232 256V152C232 138.7 242.7 128 256 128V128z"
+					/>
+				</svg>
+				<span>History</span>
+			</a>
+		</li>
 	)}
 	{CONFIG.COMMUNITY_INVITE_URL && (
 		<li class={`heading-link depth-2`}>


### PR DESCRIPTION
This PR adds a link to a file's commit history on GitHub. The link is added to the "more" menu on the right sidebar and the bottom of the page.

This is not necessary because the "edit this page" link takes you to the file on GitHub where you can check the history. Nonetheless, it may give the impression of transparency and openness.