### PR TITLE
Allow external links in sidebar

### DIFF
--- a/src/components/LeftSidebar/LeftSidebar.astro
+++ b/src/components/LeftSidebar/LeftSidebar.astro
@@ -32,7 +32,7 @@ const sidebarSections = SIDEBAR[langCode].reduce((col, item, i) => {
 						{section.children.map((child) => (
 							<li class="nav-link">
 								<a
-									href={`${Astro.site.pathname}${child.link}`}
+									href={child.link.startsWith('http') ? child.link : `${Astro.site.pathname}${child.link}`}
 									aria-current={`${currentPageMatch === child.link ? 'page' : 'false'}`}
 								>
 									{child.text}


### PR DESCRIPTION
This fixes a bug I introduced in #28 when migrating to Astro 1.x.

The Astro starter files doesn't allow external links in the left sidebar links. But we have some external links (e.g. Code of Conduct page).