### PR TITLE
Accessibility reports: Move list to the top

### DIFF
--- a/src/pages/en/reports/accessibility/index.mdx
+++ b/src/pages/en/reports/accessibility/index.mdx
@@ -14,6 +14,9 @@ import sponsors from '../../../../sponsors.json';
   <Sponsor small sponsor={sponsors.find(item => item.name=='Parcel')} />
 </SponsorsGrid>
 
+## Reports
+
+<AccessibilityReportsList />
 
 ## Data
 
@@ -40,6 +43,3 @@ The HTML that gets sent does not always reflect the efforts made by the HTML ema
 
 Email clients may also modify the HTML code that is eventually rendered on the page. This could introduce accessibility issues that the unmodified HTML email addresses. Issues introduced by email clients in the browser may not be covered in these reports.
 
-## Reports
-
-<AccessibilityReportsList />


### PR DESCRIPTION
This PR moves the reports list on https://emailmarkup.org/en/reports/accessibility/ to the top for more visibility and easier access.

The information on this page is relevant, but I think most people who land on that page will be looking for the individual reports.