### PR TITLE
Add Vision doc to featured articles list

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -118,6 +118,12 @@ const currentPage = Astro.url.pathname;
         />
 
         <FeaturedArticle 
+          title="Our Vision" 
+          desc="The Email Markup Consortium's vision for more consistent rendering in email clients."
+          link="/en/docs/vision/"
+        />
+
+        <FeaturedArticle 
           title="Data Collection" 
           desc="Learn why we are collecting a diversified set of emails and what we are doing with this unique data."
           link="https://dev.to/emailmarkup/collecting-data-1gdb"


### PR DESCRIPTION
This PR adds the Vision do to the featured articles list on the home page. I did not remove any of the existing ones. So we'd have:

1. One report
2. One blog post
3. Two docs