### PR TITLE
Last modified now

### DIFF
--- a/src/components/LastModifiedNow.astro
+++ b/src/components/LastModifiedNow.astro
@@ -1,0 +1,8 @@
+---
+const lastModifiedDate = new Date();
+const formattedLastModifiedDate = `${lastModifiedDate.getDate()} ${lastModifiedDate.toLocaleString('default', { month: 'long' })} ${lastModifiedDate.getFullYear()}`;
+---
+
+<p>
+  <b>Last modified:</b> <time datetime={lastModifiedDate.toISOString()}>{formattedLastModifiedDate}</time>
+</p>

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -24,7 +24,10 @@ const githubEditUrl = CONFIG.GITHUB_EDIT_URL && CONFIG.GITHUB_EDIT_URL + current
 
 const githubResponse = await fetch(`https://api.github.com/repos/${CONFIG.GITHUB_REPO}/commits?path=${encodeURIComponent(currentFile)}&page=1&per_page=1`);
 const githubData = await githubResponse.json();
-const lastModifiedDate = githubData.length ? new Date(githubData[0].commit.author.date) : null;
+let lastModifiedDate = githubData.length ? new Date(githubData[0].commit.author.date) : null;
+if (frontmatter.hideLastModifiedDate) {
+	lastModifiedDate = null;
+}
 
 import SponsorRandom from '@components/Sponsors/SponsorRandom';
 ---

--- a/src/pages/en/reports/email-clients/feature-support-rankings.mdx
+++ b/src/pages/en/reports/email-clients/feature-support-rankings.mdx
@@ -2,6 +2,7 @@
 title: Email Client Feature Support Rankings
 description: Email client feature support ranks in various categories such as performance, accessibility and internationalization
 layout: "@layouts/MainLayout"
+hideLastModifiedDate: true
 customHeadings:
   -
     depth: 2
@@ -26,6 +27,9 @@ customHeadings:
 
 ---
 import FeatureRanks from '@components/EmailClients/FeatureRanks';
+import LastModifiedNow from '@components/LastModifiedNow';
+
+<LastModifiedNow />
 
 [Can I Email?](https://caniemail.com) breaks down email features by the clients that support them. These features come with intrinsic value, which can be broken up into three buckets. Accessibility, performance, and internationalization (i18n).
 


### PR DESCRIPTION
Closes #54 

Component to display the last modified date as the date of the build (so it can be used in place of the last modified date of the file in git). This is useful for auto updating pages like the one referenced in #54  