### PR TITLE
Trigger Netlify deploy via webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,4 @@ All commands are run from the root of the project, from the command line:
 
 ## Automated deploys
 
-The site is set to build and deploy once a week. This is triggered by posting to a Netlify webhook from an IFTTT applet.
-
-Similar setup: https://flaviocopes.com/netlify-auto-deploy/ 
+The site is set to build and deploy once a week. This is triggered by posting to a Netlify webhook from a Render.com cron.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@docsearch/css": "^3.1.0",
         "@docsearch/react": "^3.1.0",
         "@types/react": "^17.0.45",
+        "dotenv": "^16.5.0",
         "preact": "^10.7.3",
         "react": "^18.1.0",
         "react-dom": "^18.1.0"
@@ -3036,6 +3037,17 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dset": {
       "version": "3.1.3",
@@ -8860,6 +8872,11 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+    },
+    "dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="
     },
     "dset": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@docsearch/css": "^3.1.0",
     "@docsearch/react": "^3.1.0",
     "@types/react": "^17.0.45",
+    "dotenv": "^16.5.0",
     "preact": "^10.7.3",
     "react": "^18.1.0",
     "react-dom": "^18.1.0"

--- a/trigger-deploy.mjs
+++ b/trigger-deploy.mjs
@@ -1,0 +1,45 @@
+import https from 'https';
+import dotenv from "dotenv";
+
+/**
+ * Trigger a Netlify deploy
+ * Just a post request with empty JSON
+ * See: https://docs.netlify.com/configure-builds/build-hooks/
+ *
+ * Render.com cron
+ * To avoid installing all site dependencies, set build command to npm install dotenv
+ */
+
+
+dotenv.config();
+const webhookPath = process.env.NETLIFY_WEBHOOK_PATH;
+const data = JSON.stringify({});
+
+if(!webhookPath) {
+  console.log('NETLIFY_WEBHOOK_PATH is not set in the .env file');
+  process.exit();
+}
+
+console.log('Triggering a deploy..');
+console.log(webhookPath);
+
+const options = {
+  hostname: 'api.netlify.com',
+  path: `${webhookPath}`,
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': data.length
+  }
+};
+
+const req = https.request(options);
+
+req.on('error', (e) => {
+  console.error('Request error:', e);
+});
+
+req.write(data);
+req.end();
+
+console.log('Check Netlify deploy log to confirm successful deploy!');


### PR DESCRIPTION
This PR adds a script that just makes a post request to a Netlify build webhook. The intention is to set a cron job on Render.com that runs once a week. This replaces the free IFTTT applet we used previously.

The reason we need to trigger the build once a week is to update the [Email Client Feature Support Rankings](https://emailmarkup.org/en/reports/email-clients/feature-support-rankings/) with the latest data from Can I Email.

closes #74 
